### PR TITLE
decode SMS_STATUS_REPORT without TP-PI field

### DIFF
--- a/pycrate_mobile/TS23040_SMS.py
+++ b/pycrate_mobile/TS23040_SMS.py
@@ -1098,6 +1098,7 @@ class SMS_STATUS_REPORT(SMS_TP):
         )
     def __init__(self, *args, **kwargs):
         Envelope.__init__(self, *args, **kwargs)
+        self['TP_PI'].set_transauto(lambda: True)
         self['TP_PID'].set_transauto(lambda: False if self['TP_PI']['TP_PID']() else True)
         self['TP_DCS'].set_transauto(lambda: False if self['TP_PI']['TP_DCS']() else True)
         self['TP_UD'].set_transauto(lambda: False if self['TP_PI']['TP_UDL']() else True)


### PR DESCRIPTION
As stated in TS23.040, field TP-PI of SMS-STATUS-REPORT is optional. Thus a default empty value should be provisioned. Is it the role of transparency automation? This is what I assumed in the present commit.
Here is a real SMS-STATUS-REPORT that is correctly decoded by wireshark and that needs a fix to be decoded by pycrate:

```
#! /usr/bin/env python3
# coding:utf-8

import pycrate_mobile.TS24011_PPSMS
import binascii

statusreport=binascii.unhexlify('010607913386094030f1001906300b913387540805f8811102610040408111026100504000')
rpdata = pycrate_mobile.TS24011_PPSMS.RP_DATA_MT()
rpdata.from_bytes(statusreport)
print(rpdata.show())
```

