### PR TITLE
asnobj / add attrs lazy accessor to `get_at`

### DIFF
--- a/pycrate_asn1rt/asnobj.py
+++ b/pycrate_asn1rt/asnobj.py
@@ -921,6 +921,19 @@ class ASN1Obj(Element):
     def get_val(self):
         return self._val
     
+
+    def __getattr__(self, name):
+        """
+            Lazy attribute accesor to `get_at`
+        """
+
+        # Do not hook internal attrs
+        if str.startswith(name, '_'):
+            raise AttributeError('Unknown attribute {}'.format(name))
+
+        path = name.replace('_', '-')
+        return self.get_at([path])
+
     def get_val_paths(self, curpath=[], paths=[]):
         """
         returns the list of paths of each individual basic value set into self


### PR DESCRIPTION
Implement `__getattr__` on `ASN1Obj` to call  `get_at` on unknown attributes.

Thus
```
obj.get_at(['begin', 'dialoguePortion', 'direct-reference'])
```

Could now also be accessed using: 
```
obj.begin.dialoguePortion.direct_reference
```