### PR TITLE
Adds one fuzz target for fuzz testing

### DIFF
--- a/test/fuzz/fuzz.py
+++ b/test/fuzz/fuzz.py
@@ -1,0 +1,24 @@
+from pycrate_asn1dir import TCAP_MAPv2v3
+import pycrate_core
+import pycrate_asn1rt
+from pythonfuzz.main import PythonFuzz
+
+
+@PythonFuzz
+def fuzz(buf):
+    buf = bytes(buf)
+    try:
+        M = TCAP_MAPv2v3.TCAP_MAP_Messages.TCAP_MAP_Message
+        M.from_ber(buf)
+        r = M.to_asn1()
+    except pycrate_core.charpy.CharpyErr:
+        pass
+    except pycrate_asn1rt.err.ASN1BERDecodeErr:
+        pass
+    except pycrate_core.utils_py3.PycrateErr:
+        pass
+    except AssertionError:
+        pass
+
+if __name__ == '__main__':
+    fuzz()


### PR DESCRIPTION
This PR is a draft for discussion

cc @H21lab cf https://github.com/P1sec/pycrate/blob/master/test/test_tcapmap.py#L75
cc @yevgenypats for usage of python-fuzz https://github.com/fuzzitdev/pythonfuzz

The big question is where (and which) exceptions should be handled (in the library or in the application)

More targets can easily be written.