### PR TITLE
Fix missing comma in SERVER_GNB definition

### DIFF
--- a/pycrate_corenet/Server.py
+++ b/pycrate_corenet/Server.py
@@ -89,7 +89,7 @@ class CorenetServer(object):
     #
     # NGAP Server
     SERVER_GNB = {'INET'  : socket.AF_INET,
-                  'IP'    : '10.3.1.1'
+                  'IP'    : '10.3.1.1',
                   'port'  : 38412,
                   'MAXCLI': SERVER_MAXCLI,
                   'errclo': True,


### PR DESCRIPTION
There's a comma missing on the IP key in the SERVER_GNB dictionary definition causing an error to be displayed in the setup process.