### PR TITLE
Fixed hardcoded TBCD filler byte in BufBCD.decode()

### DIFF
--- a/pycrate_mobile/TS24008_IE.py
+++ b/pycrate_mobile/TS24008_IE.py
@@ -164,11 +164,11 @@ class BufBCD(Buf):
         ret = []
         for o in num:
             msb, lsb = o>>4, o&0xf
-            if lsb == 0xF:
+            if lsb == self._filler:
                 break
             else:
                 ret.append( self._chars[lsb] )
-            if msb == 0xF:
+            if msb == self._filler:
                 break
             else:
                 ret.append( self._chars[msb] )


### PR DESCRIPTION
When working with TBCD using a filler byte different than 0xF I came across this little bug, which was caused by using a hardcoded value instead of the _filler variable.
Sorry for the polluted pull request, hope it could still be merged, or at least the change could be adopted from it in a new commit.

Kind regards,
Domi