### PR TITLE
Handle CONTAINING contraint on optional CLASS field

### DIFF
--- a/pycrate_asn1rt/asnobj.py
+++ b/pycrate_asn1rt/asnobj.py
@@ -363,8 +363,13 @@ class ASN1Obj(Element):
         except Exception:
             return ret
         cla_val_type, cla_val = self._const_tab.get(IndIdent, IndVal)
-        if cla_val_type == CLASET_UNIQ and self._const_tab_id in cla_val:
-            return (CLASET_UNIQ, cla_val[self._const_tab_id])
+        if cla_val_type == CLASET_UNIQ:
+            if self._const_tab_id in cla_val:
+                return (CLASET_UNIQ, cla_val[self._const_tab_id])
+            elif self._const_tab._cont[self._const_tab_id]._opt:
+                raise TableLookupFieldNotFoundOpt(self._const_tab_id)
+            else:
+                raise TableLookupFieldNotFoundMand(self._const_tab_id)
         elif cla_val_type == CLASET_MULT:
             # filter cla_val for the given tab_id
             cla_val = [val[self._const_tab_id] for val in cla_val if self._const_tab_id in val]
@@ -372,6 +377,8 @@ class ASN1Obj(Element):
                 return (CLASET_MULT, cla_val)
             elif cla_val:
                 return (CLASET_UNIQ, cla_val[0])
+            else:
+                raise TableLookupFieldNotFound(self._const_tab_id)
         return ret
     
     def _get_tab_obj_uniq(self):
@@ -1990,3 +1997,14 @@ def _restore_ber_params():
     ASN1CodecBER.ENC_TIME_CANON = __ber_enc_time_canon
     ASN1CodecBER.ENC_DEF_CANON  = __ber_enc_def_canon
 
+
+class TableLookupFieldNotFound(Exception):
+    """The named field was not found on the LUT entry."""
+
+
+class TableLookupFieldNotFoundOpt(TableLookupFieldNotFound):
+    """The optional field was now found on the LUT entry."""
+
+
+class TableLookupFieldNotFoundMand(TableLookupFieldNotFound):
+    """The mandatory field was not found on the LUT entry."""

--- a/pycrate_asn1rt/asnobj_str.py
+++ b/pycrate_asn1rt/asnobj_str.py
@@ -410,8 +410,9 @@ Specific constraints attributes:
                         self._const_cont.from_aper_ws(char)
                     else:
                         self._const_cont.from_uper_ws(char)
-                except Exception:
-                    if not self._SILENT:
+                except Exception as e:
+                    if not self._SILENT and \
+                            not isinstance(e, (ASN1PERDecodeErr, TableLookupFieldNotFoundOpt)):
                         asnlog('BIT_STR.__from_per_ws_buf: %s, CONTAINING object decoding failed'\
                                % self._name)
                     self._val = (bytes_to_uint(buf, bl), bl)
@@ -514,8 +515,9 @@ Specific constraints attributes:
                         self._const_cont.from_aper(char)
                     else:
                         self._const_cont.from_uper(char)
-                except Exception:
-                    if not self._SILENT:
+                except Exception as e:
+                    if not self._SILENT and \
+                            not isinstance(e, (ASN1PERDecodeErr, TableLookupFieldNotFoundOpt)):
                         asnlog('BIT_STR.__from_per_buf: %s, CONTAINING object decoding failed'\
                                % self._name)
                     if bl:
@@ -862,7 +864,8 @@ Specific constraints attributes:
                 try:
                     Obj.from_ber(char, single=False)
                 except Exception as e:
-                    if not self._SILENT and not isinstance(e, TableLookupFieldNotFoundOpt):
+                    if not self._SILENT and \
+                            not isinstance(e, (ASN1BERDecodeErr, TableLookupFieldNotFoundOpt)):
                         asnlog('BIT_STR.__from_ber_buf: %s, CONTAINING object decoding failed'\
                                % self._name)
                     if bl:
@@ -1706,8 +1709,9 @@ Specific constraints attributes:
                 Obj._parent = self._parent
                 try:
                     Obj.from_ber(char, single=False)
-                except Exception:
-                    if not self._SILENT:
+                except Exception as e:
+                    if not self._SILENT and \
+                            not isinstance(e, (ASN1BERDecodeErr, TableLookupFieldNotFoundOpt)):
                         asnlog('OCT_STR.__from_ber_buf: %s, CONTAINING object decoding failed'\
                                % self._name)
                     Obj._parent = _const_cont_par

--- a/pycrate_asn1rt/asnobj_str.py
+++ b/pycrate_asn1rt/asnobj_str.py
@@ -861,8 +861,8 @@ Specific constraints attributes:
                 Obj._parent = self._parent
                 try:
                     Obj.from_ber(char, single=False)
-                except Exception:
-                    if not self._SILENT:
+                except Exception as e:
+                    if not self._SILENT and not isinstance(e, TableLookupFieldNotFoundOpt):
                         asnlog('BIT_STR.__from_ber_buf: %s, CONTAINING object decoding failed'\
                                % self._name)
                     if bl:


### PR DESCRIPTION
Resolves #139

This adds logic to the decoding of `BIT STRING` and `OCTET STRING` values
with a `CONTAINING` constraint.

An exception is raised if a matching object information instance was found
on the lookup-table of the `OPEN` object, but the instance did not include
the referenced field.

The exception causes processing of the `CONTAINING` constraint to abort,
and fall back to decoding the value as a bare `BIT/OCTET STRING`.

The case where the referenced field is `OPTIONAL` on the `CLASS` definition
is distinguishable by the type of exception raised.
A warning is only printed where the field is non-`OPTIONAL`.

Updated exception handling has been implemented for BER/DER, and those that
clearly follow the same logic.

Similar logic may be needed in the JER/OER/etc. cases. I am not familiar
enough with those code-paths to provide this without some guidance.
