### PR TITLE
fix: TS24008 Networkname from dict

### DIFF
--- a/pycrate_mobile/TS24008_IE.py
+++ b/pycrate_mobile/TS24008_IE.py
@@ -922,7 +922,7 @@ class NetworkName(Envelope):
     def set_val(self, vals):
         Name = None
         if isinstance(vals, dict) and 'Name' in vals:
-            Name = dict(vals['Name'])
+            Name = vals['Name']
             del vals['Name']
         elif isinstance(vals, (tuple, list)) and len(vals) == 5:
             vals = list(vals)


### PR DESCRIPTION
Trying to create a NAS5G/FGMMConfigurationUpdateCommand payload, an exception was raised. I think the problem is in TS24008_IE.py.

Let's take an example:

```python
import pycrate_mobile.TS24008_IE

hex = '10004f00700065006e003500470053'

n1 = pycrate_mobile.TS24008_IE.NetworkName()
n1.from_bytes(bytes.fromhex(hex))
val = n1.get_val_d()
print(val)

n2 = pycrate_mobile.TS24008_IE.NetworkName()
n2.set_val(val)
assert n2.to_bytes().hex() == hex
```

`val` equals to `{'Ext': 0, 'Coding': 1, 'AddCountryInitials': 0, 'SpareBits': 0, 'Name': b'\x00O\x00p\x00e\x00n\x005\x00G\x00S'}` and the line `n2.set_val(val)` raises the exception:

```shell
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.8/dist-packages/pycrate_mobile/TS24008_IE.py", line 925, in set_val
    Name = dict(vals['Name'])
TypeError: cannot convert dictionary update sequence element #0 to a sequence
```

The current request fix this.