### PR TITLE
Asn recurs

### DIFF
--- a/pycrate_asn1rt/asnobj_construct.py
+++ b/pycrate_asn1rt/asnobj_construct.py
@@ -581,11 +581,11 @@ Specific attributes:
                 assert( ident[:5] == '_ext_' )
                 ret = {ident[5:] : self._val[1]}
             return ret
-
+    
     ###
     # conversion between internal value and ASN.1 OER/COER encoding
     ###
-
+    
     def _oer_tag_class(self):
         try:
             tag_class, tag = next(t for t, ident in self._cont_tags.items()
@@ -1320,17 +1320,17 @@ class _CONSTRUCT(ASN1Obj):
                     for ident, comp_val in val.items():
                         ret['_ext_%s' % ident] = comp_val
                 return ret
-
+    
     ###
     # conversion between internal value and ASN.1 OER/COER encoding
     ###
-
+    
     def _to_oer(self):
         GEN = []
         if not self._cont and self._ext is None:
             # empty sequence
             return GEN
-
+        
         extended = False
         ext_bit = 0
         if self._ext is not None:
@@ -1339,10 +1339,10 @@ class _CONSTRUCT(ASN1Obj):
                 if k in self._ext or k[:5] == '_ext_':
                     extended = True
                     break
-
+            
             GEN.append((T_UINT, (1 if extended else 0), 1))
             ext_bit = 1
-
+        
         # generate the bitmap preambule for optional / default components of the root part
         opt_len = 0
         Bv = 0
@@ -1355,7 +1355,7 @@ class _CONSTRUCT(ASN1Obj):
                         # the value provided equals the default one
                         # hence will not be encoded
                         if not self._SILENT:
-                            asnlog('_CONSTRUCT._to_oer: %s.%s, removing value equal ' \
+                            asnlog('_CONSTRUCT._to_oer: %s.%s, removing value equal '\
                                    'to the default one' % (self.fullname(), ident))
                         del self._val[ident]
                     else:
@@ -1364,13 +1364,13 @@ class _CONSTRUCT(ASN1Obj):
                         opt_idents.append(ident)
         else:
             opt_idents = []
-
+        
         # Padding bits
         pad_bits = 8 - ((opt_len + ext_bit) % 8)
         pad_bits = 0 if (pad_bits == 8) else pad_bits
         Bv = Bv << pad_bits
         GEN.append( (T_UINT, Bv, opt_len + pad_bits) )
-
+        
         # encode components in the root part
         if self.TYPE == TYPE_SET:
             root_canon = self._root_canon
@@ -1385,7 +1385,7 @@ class _CONSTRUCT(ASN1Obj):
                 Comp._val = self._val[ident]
                 GEN.extend( Comp._to_oer() )
                 Comp._parent = _par
-
+        
         # encode components in the extension part
         if extended:
             # generate the structure for all known present extension
@@ -1403,8 +1403,7 @@ class _CONSTRUCT(ASN1Obj):
                         # group present in the encoding
                         Comp = self._ext_group_obj[gid]
                         Comp._val = grp_val
-                        _gen_ext.extend( ASN1CodecOER.encode_open_type(
-                            Comp.to_oer() ))
+                        _gen_ext.extend( ASN1CodecOER.encode_open_type(Comp.to_oer()) )
                         Bm.append(cnt)
                 else:
                     if ident in self._val:
@@ -1413,12 +1412,11 @@ class _CONSTRUCT(ASN1Obj):
                         _par = Comp._parent
                         Comp._parent = self
                         Comp._val = self._val[ident]
-                        _gen_ext.extend( ASN1CodecOER.encode_open_type(
-                            Comp.to_oer()))
+                        _gen_ext.extend( ASN1CodecOER.encode_open_type(Comp.to_oer()) )
                         Comp._parent = _par
                         Bm.append(cnt)
                 cnt += 1
-
+            
             # generate the structure for all unknown present extension
             unk_idents = [i for i in self._val if i[:5] == '_ext_']
             if unk_idents:
@@ -1431,13 +1429,12 @@ class _CONSTRUCT(ASN1Obj):
                             self._val[ident]) )
                         Bm.append(ind)
                     elif not self._SILENT:
-                        asnlog('_CONSTRUCT._to_oer: %s.%s, '
-                               'invalid unknown extension index' \
+                        asnlog('_CONSTRUCT._to_oer: %s.%s, invalid unknown extension index'\
                                % (self.fullname(), ident))
-
+            
             if not Bm:
                 return GEN
-
+            
             # generate the bitmap preambule for extended (group of) components
             # bitmap length is encoded with a normally small value
             ldet = max(max(Bm), len(self._ext_nest))
@@ -1447,20 +1444,19 @@ class _CONSTRUCT(ASN1Obj):
             pad_bits = uint_bytelen(ext_bitmap)*8 - ldet
             ext_bitmap = ext_bitmap << pad_bits
             ext_bmp_len = pad_bits + ldet
-            GEN.extend(ASN1CodecOER.encode_length_determinant(1 +
-                                                              ext_bmp_len//8))
+            GEN.extend(ASN1CodecOER.encode_length_determinant(1 + ext_bmp_len//8))
             GEN.append( (T_UINT, pad_bits, 8) )
             GEN.append( (T_UINT, ext_bitmap, ext_bmp_len) )
             GEN.extend(_gen_ext)
-
+        
         return GEN
-
+    
     def _to_oer_ws(self):
         GEN = []
         if not self._cont and self._ext is None:
             # empty sequence
             return GEN
-
+        
         extended = False
         ext_bit = 0
         if self._ext is not None:
@@ -1472,7 +1468,7 @@ class _CONSTRUCT(ASN1Obj):
 
             GEN.append(Uint('Extension', val=(1 if extended else 0), bl=1))
             ext_bit = 1
-
+        
         # generate the bitmap preambule for optional / default components of the root part
         opt_len = 0
         Bv = 0
@@ -1485,7 +1481,7 @@ class _CONSTRUCT(ASN1Obj):
                         # the value provided equals the default one
                         # hence will not be encoded
                         if not self._SILENT:
-                            asnlog('_CONSTRUCT._to_oer: %s.%s, removing value equal ' \
+                            asnlog('_CONSTRUCT._to_oer: %s.%s, removing value equal '\
                                    'to the default one' % (self.fullname(), ident))
                         del self._val[ident]
                     else:
@@ -1494,15 +1490,14 @@ class _CONSTRUCT(ASN1Obj):
                         opt_idents.append(ident)
         else:
             opt_idents = []
-
+        
         # Padding bits
         pad_bits = 8 - ((opt_len + ext_bit) % 8)
         pad_bits = 0 if (pad_bits == 8) else pad_bits
         Bv = Bv << pad_bits
         GEN.append( Uint('Root-Bmp', val=Bv, bl=opt_len + pad_bits) )
-
         GEN = [Envelope('Preamble', GEN=tuple(GEN))]
-
+        
         # encode components in the root part
         if self.TYPE == TYPE_SET:
             root_canon = self._root_canon
@@ -1517,7 +1512,7 @@ class _CONSTRUCT(ASN1Obj):
                 Comp._val = self._val[ident]
                 GEN.append( Comp._to_oer_ws() )
                 Comp._parent = _par
-
+        
         # encode components in the extension part
         if extended:
             # generate the structure for all known present extension
@@ -1535,8 +1530,7 @@ class _CONSTRUCT(ASN1Obj):
                         # group present in the encoding
                         Comp = self._ext_group_obj[gid]
                         Comp._val = grp_val
-                        _gen_ext.append( ASN1CodecOER.encode_open_type_ws(
-                            Comp.to_oer() ))
+                        _gen_ext.append( ASN1CodecOER.encode_open_type_ws(Comp.to_oer() ))
                         Bm.append(cnt)
                 else:
                     if ident in self._val:
@@ -1545,12 +1539,11 @@ class _CONSTRUCT(ASN1Obj):
                         _par = Comp._parent
                         Comp._parent = self
                         Comp._val = self._val[ident]
-                        _gen_ext.append( ASN1CodecOER.encode_open_type_ws(
-                            Comp.to_oer()))
+                        _gen_ext.append( ASN1CodecOER.encode_open_type_ws(Comp.to_oer()))
                         Comp._parent = _par
                         Bm.append(cnt)
                 cnt += 1
-
+            
             # generate the structure for all unknown present extension
             unk_idents = [i for i in self._val if i[:5] == '_ext_']
             if unk_idents:
@@ -1563,14 +1556,13 @@ class _CONSTRUCT(ASN1Obj):
                             self._val[ident]) )
                         Bm.append(ind)
                     elif not self._SILENT:
-                        asnlog('_CONSTRUCT._to_oer: %s.%s, '
-                               'invalid unknown extension index' \
+                        asnlog('_CONSTRUCT._to_oer: %s.%s, invalid unknown extension index'\
                                % (self.fullname(), ident))
-
+            
             if not Bm:
                 self._struct = Envelope(self._name, GEN=tuple(GEN))
                 return self._struct
-
+            
             # generate the bitmap preambule for extended (group of) components
             # bitmap length is encoded with a normally small value
             ldet = max(max(Bm), len(self._ext_nest))
@@ -1581,19 +1573,16 @@ class _CONSTRUCT(ASN1Obj):
             ext_bitmap = ext_bitmap << pad_bits
             ext_bmp_len = pad_bits + ldet
             ext_bmp_struct = []
-            ext_bmp_struct.append(ASN1CodecOER.encode_length_determinant_ws(1 +
-                                                              ext_bmp_len//8))
+            ext_bmp_struct.append( ASN1CodecOER.encode_length_determinant_ws(1 + ext_bmp_len//8) )
             ext_bmp_struct.append( Uint('Initial-octet', val=pad_bits, bl=8) )
-            ext_bmp_struct.append( Uint('Bitmap', val=ext_bitmap,
-                                        bl=ext_bmp_len) )
-            ext_bmp_struct = Envelope('Extension-bmp',
-                                      GEN=tuple(ext_bmp_struct))
+            ext_bmp_struct.append( Uint('Bitmap', val=ext_bitmap, bl=ext_bmp_len) )
+            ext_bmp_struct = Envelope('Extension-bmp', GEN=tuple(ext_bmp_struct))
             GEN.append(ext_bmp_struct)
             GEN.extend(_gen_ext)
-
+        
         self._struct = Envelope(self._name, GEN=tuple(GEN))
         return self._struct
-
+    
     def _from_oer(self, char):
         GEN, val = [], {}
         if not self._cont and self._ext is None:
@@ -1675,8 +1664,7 @@ class _CONSTRUCT(ASN1Obj):
                             Comp._parent = _par
                     else:
                         # unknown extension
-                        val['_ext_%r' % i] = \
-                            ASN1CodecOER.decode_open_type(char)
+                        val['_ext_%r' % i] = ASN1CodecOER.decode_open_type(char)
         self._val = val
         return
     

--- a/pycrate_asn1rt/asnobj_ext.py
+++ b/pycrate_asn1rt/asnobj_ext.py
@@ -642,11 +642,11 @@ Single value: Python 2-tuple
                 Obj = self._get_val_obj(self._val[0])
             Obj._val = self._val[1]
             return Obj._to_jval()
-
+    
     ###
     # conversion between internal value and ASN.1 OER/COER encoding
     ###
-
+    
     def _from_oer(self, char):
         # try to get a defined object from a table constraint
         if self._TAB_LUT and self._const_tab and self._const_tab_at:
@@ -671,7 +671,7 @@ Single value: Python 2-tuple
         #
         val_bytes = ASN1CodecOER.decode_open_type(char)
         val = Obj.from_oer(val_bytes) if (Obj is not None) else val_bytes
-
+        
         if Obj is None:
             if self._const_val:
                 asnlog('OPEN._from_per: %s, potential type constraint(s) available but unused' \
@@ -684,7 +684,7 @@ Single value: Python 2-tuple
             else:
                 self._val = (Obj.TYPE, val)
         return
-
+    
     def _from_oer_ws(self, char):
         # try to get a defined object from a table constraint
         if self._TAB_LUT and self._const_tab and self._const_tab_at:
@@ -720,7 +720,7 @@ Single value: Python 2-tuple
             else:
                 self._val = (Obj.TYPE, val)
         self._struct = Envelope(self._name, GEN=tuple(GEN))
-
+    
     def _to_oer(self):
         if isinstance(self._val[0], ASN1Obj):
             Obj = self._val[0]
@@ -730,7 +730,7 @@ Single value: Python 2-tuple
             Obj = self._get_val_obj(self._val[0])
         Obj._val = self._val[1]
         return ASN1CodecOER.encode_open_type(Obj.to_oer())
-
+    
     def _to_oer_ws(self):
         if isinstance(self._val[0], ASN1Obj):
             Obj = self._val[0]

--- a/pycrate_asn1rt/asnobj_str.py
+++ b/pycrate_asn1rt/asnobj_str.py
@@ -1034,16 +1034,16 @@ Specific constraints attributes:
                         return {'value': uint_to_hex(val<<bl_rnd, bl+bl_rnd), 'length': bl}
                     else:
                         return {'value': uint_to_hex(val, bl), 'length': bl}
-
+    
     ###
     # conversion between internal value and ASN.1 OER/COER encoding
     ###
-
+    
     def _to_oer(self):
         if isinstance(self._val, set):
             self._names_to_val()
-
-        ## Now check if the value is contained object or just number
+        
+        # Now check if the value is contained object or just number
         if not isinstance(self._val[0], integer_types):
             # 1) value is for a contained object to be encoded
             Cont = self._get_val_obj(self._val[0])
@@ -1072,23 +1072,22 @@ Specific constraints attributes:
                 pad_bits = 0
                 l_val = 0
                 _gen = [(T_BYTES, b'', l_val)]
-
+        
         if self._const_sz:
             if (self._const_sz._ev is None) and (self._const_sz.ra == 1):
                 # Fixed size constrains
                 return _gen
-
+        
         # Variable size constrains
-        GEN = ASN1CodecOER.encode_length_determinant(((l_val + pad_bits) // 8)
-                                                     + 1)
+        GEN = ASN1CodecOER.encode_length_determinant(((l_val + pad_bits) // 8) + 1)
         GEN.append((T_UINT, pad_bits, 8))  # Initial octet
         GEN.extend(_gen)
         return GEN
-
+    
     def _to_oer_ws(self):
         if isinstance(self._val, set):
             self._names_to_val()
-
+        
         ## Now check if the value is contained object or just number
         if not isinstance(self._val[0], integer_types):
             # 1) value is for a contained object to be encoded
@@ -1120,21 +1119,20 @@ Specific constraints attributes:
                 pad_bits = 0
                 l_val = 0
                 _gen = [Buf('V', b'', l_val)]
-
+        
         if self._const_sz:
             if (self._const_sz._ev is None) and (self._const_sz.ra == 1):
                 # Fixed size constrains
                 self._struct = Envelope(self._name, GEN=tuple(_gen))
                 return self._struct
-
+        
         # Variable size constrains
-        GEN = [ASN1CodecOER.encode_length_determinant_ws(
-            ((l_val + pad_bits) // 8) + 1)]
+        GEN = [ASN1CodecOER.encode_length_determinant_ws(((l_val + pad_bits) // 8) + 1)]
         GEN.append(Uint('Initial octet', val=pad_bits, bl=8))
         GEN.extend(_gen)
         self._struct = Envelope(self._name, GEN=tuple(GEN))
         return self._struct
-
+    
     def _from_oer(self, char):
         if self._const_sz:
             if (self._const_sz._ev is None) and (self._const_sz.ra == 1):
@@ -1151,13 +1149,13 @@ Specific constraints attributes:
             Cont.from_oer(char)
             self._val = (self._const_cont._typeref.called, Cont._val)
             return
-
+        
         # Variable size constraints
         l_det = ASN1CodecOER.decode_length_determinant(char)
         pad_bits = char.get_uint(8)
         l_val = 8*(l_det - 1) - pad_bits
         self._val = (char.get_uint(l_val+pad_bits) >> pad_bits, l_val)
-
+    
     def _from_oer_ws(self, char):
         if self._const_sz:
             if (self._const_sz._ev is None) and (self._const_sz.ra == 1):
@@ -1180,7 +1178,7 @@ Specific constraints attributes:
             self._val = (self._const_cont._typeref.called, Cont._val)
             self._struct = Envelope(self._name, GEN=(_gen,))
             return
-
+        
         # Variable size constraints
         l_det, _gen = ASN1CodecOER.decode_length_determinant_ws(char)
         _gen = [_gen]
@@ -1451,7 +1449,7 @@ Specific constraints attributes:
         # decoded as unconstrained
         self.__from_per(char, unconst=True)
         return
-        
+    
     def __from_per(self, char, unconst=False):
         if self._const_cont is not None:
             if self._const_cont_enc is not None:
@@ -1825,18 +1823,18 @@ Specific constraints attributes:
                     return {Cont._typeref.called[1]: val}
                 else:
                     return {Cont.TYPE: val}
-
+    
     ###
     # conversion between internal value and ASN.1 OER/COER encoding
     ###
-
+    
     def _from_oer(self, char):
         if self._const_sz:
             if (self._const_sz._ev is None) and (self._const_sz.ra == 1):
                 # Fixed
                 self._val = char.get_bytes(self._const_sz.lb * 8)
                 return
-
+        
         # Variable size constraint
         l_val = ASN1CodecOER.decode_length_determinant(char)
         val = char.get_bytes(l_val * 8)
@@ -1851,7 +1849,7 @@ Specific constraints attributes:
             self._val = (self._const_cont._typeref.called[1], Cont._val)
         else:
             self._val = val
-
+    
     def _from_oer_ws(self, char):
         if self._const_sz:
             if (self._const_sz._ev is None) and (self._const_sz.ra == 1):
@@ -1861,12 +1859,12 @@ Specific constraints attributes:
                 self._val = val.get_val()
                 self._struct = Envelope(self._name, GEN=(val,))
                 return
-
+        
         # Variable size constraints
         l_val, _gen = ASN1CodecOER.decode_length_determinant_ws(char)
         val = Buf('V', bl=8 * l_val)
         val._from_char(char)
-
+        
         if self._const_cont:
             # Contained by constraint
             Cont = self._get_val_obj(self._const_cont._typeref.called)
@@ -1879,49 +1877,46 @@ Specific constraints attributes:
         else:
             _gen.append(val)
             self._val = val.get_val()
-
+        
         self._struct = Envelope(self._name, GEN=(_gen,))
-
+    
     def __to_coer_buf(self):
         Cont = self._get_val_obj(self._val[0])
         if Cont == self._const_cont and self._const_cont_enc is not None:
             # TODO: different codec to be used
-            raise (
-                ASN1NotSuppErr('{0}: specific CONTAINING encoder unhandled' \
-                               .format(self.fullname())))
+            raise(ASN1NotSuppErr('{0}: specific CONTAINING encoder unhandled'\
+                                 .format(self.fullname())))
         Cont._val = self._val[1]
         buf = Cont.to_coer()
         return buf, Cont
-
+    
     def __to_coer_ws_buf(self):
         Cont = self._get_val_obj(self._val[0])
         if Cont == self._const_cont and self._const_cont_enc is not None:
             # TODO: different codec to be used
-            raise (
-                ASN1NotSuppErr('{0}: specific CONTAINING encoder unhandled' \
-                               .format(self.fullname())))
+            raise(ASN1NotSuppErr('{0}: specific CONTAINING encoder unhandled'\
+                                 .format(self.fullname())))
         Cont._val = self._val[1]
         buf = Cont.to_coer_ws()
         return buf, Cont
-
+    
     def _to_oer(self):
         if not isinstance(self._val, bytes_types):
             buf, wrapped = self.__to_coer_buf()
         else:
             buf, wrapped = self._val, None
-
+        
         try:
-            if ((self._const_sz._ev is None) and
-                    (self._const_sz.lb == self._const_sz.ub)):
+            if ((self._const_sz._ev is None) and (self._const_sz.lb == self._const_sz.ub)):
                 return [(T_BYTES, buf, len(buf)*8)]
         except AttributeError:
             pass
-
+        
         # Means that it has variable constraint or no constraint
         GEN = ASN1CodecOER.encode_length_determinant(len(buf))
         GEN.append((T_BYTES, buf, len(buf) * 8))
         return GEN
-
+    
     def _to_oer_ws(self):
         if not isinstance(self._val, bytes_types):
             buf, wrapped = self.__to_coer_ws_buf()
@@ -1929,15 +1924,14 @@ Specific constraints attributes:
             buf, wrapped = self._val, None
 
         _gen = Buf('V', val=buf, bl=len(buf)*8)
-
+        
         try:
-            if ((self._const_sz._ev is None) and
-                    (self._const_sz.lb == self._const_sz.ub)):
+            if ((self._const_sz._ev is None) and (self._const_sz.lb == self._const_sz.ub)):
                 self._struct = Envelope(self._name, GEN=(_gen,))
                 return self._struct
         except AttributeError:
             pass
-
+        
         # Means that it has variable constraint or no constraint
         GEN = ASN1CodecOER.encode_length_determinant_ws(len(buf))
         GEN.append(_gen)
@@ -2768,32 +2762,30 @@ Virtual parent for any ASN.1 *String object
         
         def _to_jval(self):
             return self._val
-
+    
     ###
     # conversion between internal value and ASN.1 OER/COER encoding
     ###
-
+    
     def _from_oer(self, char):
         try:
-            if ((self._const_sz.rdyn == 0) and
-                    (self._const_sz._ev is None) and
-                    (self._clen is not None)):
+            if ((self._const_sz.rdyn == 0) and (self._const_sz._ev is None) \
+            and (self._clen is not None)):
                 # Fixed size
                 b_len = round_p2(self._clen) * self._const_sz.lb
                 self._val = self._decode_oer_cont(char.get_bytes(b_len))
                 return
         except AttributeError:
             pass
-
+        
         # All other variants
         l_det = ASN1CodecOER.decode_length_determinant(char)
         self._val = self._decode_oer_cont(char.get_bytes(l_det * 8))
-
+    
     def _from_oer_ws(self, char):
         try:
-            if ((self._const_sz.rdyn == 0) and
-                    (self._const_sz._ev is None) and
-                    (self._clen is not None)):
+            if ((self._const_sz.rdyn == 0) and (self._const_sz._ev is None) \
+            and (self._clen is not None)):
                 # Fixed size
                 b_len = round_p2(self._clen) * self._const_sz.lb
                 buf = Buf('V', bl=b_len)
@@ -2803,7 +2795,7 @@ Virtual parent for any ASN.1 *String object
                 return
         except AttributeError:
             pass
-
+        
         # All other variants
         l_det, _gen = ASN1CodecOER.decode_length_determinant_ws(char)
         _gen = [_gen]
@@ -2812,61 +2804,59 @@ Virtual parent for any ASN.1 *String object
         _gen.append(buf)
         self._struct = Envelope(self._name, GEN=tuple(_gen))
         self._val = self._decode_oer_cont(buf.to_bytes())
-
+    
     def _decode_oer_cont(self, content_bytes):
         if self._codec is None:
-            raise(ASN1NotSuppErr('{0}: ISO 2022 codec not supported' \
+            raise(ASN1NotSuppErr('{0}: ISO 2022 codec not supported'\
                                  .format(self.fullname())))
         try:
             return content_bytes.decode(self._codec)
         except Exception as err:
-            raise(ASN1OERDecodeErr('{0}: invalid character, Python codec error, {1}' \
+            raise(ASN1OERDecodeErr('{0}: invalid character, Python codec error, {1}'\
                                    .format(self.fullname(), err)))
-
+    
     def _encode_oer_cont(self):
         if self._codec is None:
-            raise(ASN1NotSuppErr('{0}: ISO 2022 codec not supported' \
+            raise(ASN1NotSuppErr('{0}: ISO 2022 codec not supported'\
                                  .format(self.fullname())))
         try:
             return self._val.encode(self._codec)
         except Exception as err:
-            raise(ASN1OEREncodeErr('{0}: invalid character, Python codec error, {1}' \
+            raise(ASN1OEREncodeErr('{0}: invalid character, Python codec error, {1}'\
                                    .format(self.fullname(), err)))
-
+    
     def _to_oer(self):
         buf = self._encode_oer_cont()
         l_buf = len(buf)
         buf = [(T_BYTES, buf, l_buf * 8)]
-
+        
         try:
-            if ((self._const_sz.rdyn == 0) and
-                    (self._const_sz._ev is None) and
-                    (self._clen is not None)):
+            if ((self._const_sz.rdyn == 0) and (self._const_sz._ev is None) \
+            and (self._clen is not None)):
                 # Fixed size
                 return buf
         except AttributeError:
             pass
-
+        
         # All other variants
         GEN = ASN1CodecOER.encode_length_determinant(l_buf)
         GEN.extend(buf)
         return GEN
-
+    
     def _to_oer_ws(self):
         buf = self._encode_oer_cont()
         l_buf = len(buf)
         buf = Buf('V', val=buf, bl=l_buf * 8)
 
         try:
-            if ((self._const_sz.rdyn == 0) and
-                    (self._const_sz._ev is None) and
-                    (self._clen is not None)):
+            if ((self._const_sz.rdyn == 0) and (self._const_sz._ev is None) \
+            and (self._clen is not None)):
                 # Fixed size
                 self._struct = Envelope(self._name, GEN=(buf,))
                 return self._struct
         except AttributeError:
             pass
-
+        
         # All other variants
         GEN = [ASN1CodecOER.encode_length_determinant_ws(l_buf)]
         GEN.append(buf)
@@ -2988,7 +2978,10 @@ ASN.1 basic type IA5String object
     
     _codec    = 'ascii'
     _clen     = 7
-    _ALPHA_RE = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'
+    _ALPHA_RE = \
+    '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16'\
+    '\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOP'\
+    'QRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'
     
     TYPE  = TYPE_STR_IA5
     TAG   = 22
@@ -3018,7 +3011,8 @@ ASN.1 basic type VisibleString object
     
     _codec    = 'ascii'
     _clen     = 7
-    _ALPHA_RE =  '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}'
+    _ALPHA_RE = \
+    '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}'
     
     TYPE  = TYPE_STR_VIS
     TAG   = 26
@@ -3248,7 +3242,7 @@ Single value: Python 7-tuple of str or None
         else:
             asc = ''.join(self._val)
         return asc
-    
+
 
 class TIME_GEN(_Time):
     __doc__ = """


### PR DESCRIPTION
These changes are for the ASN.1 runtime. They enable a cleaner decoding, mostly for constructed objects, which makes possible to decode recursive ASN.1 constructs.