### PR TITLE
Update TS24501_IE.py

### DIFF
--- a/pycrate_mobile/TS24501_IE.py
+++ b/pycrate_mobile/TS24501_IE.py
@@ -2553,8 +2553,8 @@ class QoSRule(Envelope):
         Uint8('Precedence', trans=True), # optional
         Envelope('Flow', GEN=(
             Uint('spare', bl=1),
-            Uint('Segregation', bl=2),
-            Uint('QFI', bl=5)),
+            Uint('Segregation', bl=1),
+            Uint('QFI', bl=6)),
             trans=True) # optional
         )
     


### PR DESCRIPTION
There is a typo on QFI / segregation field length in QoSRule information element.
- QFI : 5 -> 6 bits lenght
- Segegration -> 2 -> 1 bit length